### PR TITLE
Utils/graph

### DIFF
--- a/src/main/java/hu/unideb/inf/utils/DirectedGraph.java
+++ b/src/main/java/hu/unideb/inf/utils/DirectedGraph.java
@@ -1,0 +1,14 @@
+package hu.unideb.inf.utils;
+
+import java.util.Set;
+
+/**
+ * DirectedGraph graphs is a kind of Graph.
+ * Edges connect two nodes.
+ * Directed means that A->B does not imply B->A.
+ * @param <N>
+ */
+public interface DirectedGraph<N> extends Graph<N>{
+
+    void addDirectedEdge(N node0, N node1) ;
+}

--- a/src/main/java/hu/unideb/inf/utils/Graph.java
+++ b/src/main/java/hu/unideb/inf/utils/Graph.java
@@ -1,0 +1,14 @@
+package hu.unideb.inf.utils;
+
+import java.util.Set;
+
+/**
+ * Graph represents nodes and their connecting edges.
+ * An edge can be directed or undirected.
+ * These are specified in UndirectedGraph and DirectedGraph.
+ * @param <N>
+ */
+public interface Graph<N> {
+
+    Set<N> getNodesReachableFrom(N source);
+}

--- a/src/main/java/hu/unideb/inf/utils/HashGraph.java
+++ b/src/main/java/hu/unideb/inf/utils/HashGraph.java
@@ -1,0 +1,51 @@
+package hu.unideb.inf.utils;
+
+import lombok.Data;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A basic implementation of a graph.
+ *
+ * @param <N>
+ */
+public class HashGraph<N> implements UndirectedGraph<N>, DirectedGraph<N> {
+
+    /**
+     * This class represents a directed edge, which connects two nodes.
+     * The directed edge goes from source to target.
+     */
+    @Data
+    private class Edge {
+        private final N source;
+        private final N target;
+    }
+
+    private Set<Edge> edges = new HashSet<>();
+
+    @Override
+    public void addUndirectedEdge(N node0, N node1) {
+        Objects.requireNonNull(node0);
+        Objects.requireNonNull(node1);
+        edges.add(new Edge(node0, node1));
+        edges.add(new Edge(node1, node0));
+    }
+
+    @Override
+    public void addDirectedEdge(N source, N target) {
+        Objects.requireNonNull(source);
+        Objects.requireNonNull(target);
+        edges.add(new Edge(source, target));
+    }
+
+    @Override
+    public Set<N> getNodesReachableFrom(N src) {
+        return edges
+                .stream()
+                .filter(edge -> edge.getSource().equals(src))
+                .map(edge -> edge.getTarget()).collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/hu/unideb/inf/utils/UndirectedGraph.java
+++ b/src/main/java/hu/unideb/inf/utils/UndirectedGraph.java
@@ -1,0 +1,12 @@
+package hu.unideb.inf.utils;
+
+/**
+ * Undirected graphs is a kind of Graph.
+ * Edges connect two nodes.
+ * Undirected means that A->B implies B->A.
+ * @param <N>
+ */
+public interface UndirectedGraph<N> extends Graph<N>{
+
+    void addUndirectedEdge(N node0, N node1) ;
+}

--- a/src/test/java/hu/unideb/inf/utils/HashGraphTest.java
+++ b/src/test/java/hu/unideb/inf/utils/HashGraphTest.java
@@ -1,0 +1,135 @@
+package hu.unideb.inf.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class HashGraphTest {
+
+    @Test
+    void given_graph_when_addDirectedEdgeAndSourceIsNull_Throw() {
+        // given
+        HashGraph<Integer> g = new HashGraph<Integer>();
+        // when, then
+        assertThrows(NullPointerException.class, () -> g.addDirectedEdge(null, 0));
+    }
+
+    @Test
+    void given_graph_when_addDirectedEdgeAndTargetIsNull_Throw() {
+        // given
+        HashGraph<Integer> g = new HashGraph<Integer>();
+        // when, then
+        assertThrows(NullPointerException.class, () -> g.addDirectedEdge(0, null));
+    }
+
+    @Test
+    void given_graph_when_addDirectedEdgeAndBothAreNull_Throw() {
+        // given
+        HashGraph<Integer> g = new HashGraph<Integer>();
+        // when, then
+        assertThrows(NullPointerException.class, () -> g.addDirectedEdge(null, null));
+    }
+
+    @Test
+    void given_directedEmptyGraph_when_getNodesReachableFrom0_ReturnEmpty() {
+        // given
+        DirectedGraph<Integer> g = new HashGraph<Integer>();
+        // when
+        var res = g.getNodesReachableFrom(0);
+        // then
+        Set<Integer> expected = new HashSet<>();
+        assertEquals(expected, res);
+    }
+
+    @Test
+    void given_directed0to0_when_getNodesReachableFrom0_Return0() {
+        // given
+        DirectedGraph<Integer> g = new HashGraph<Integer>();
+        g.addDirectedEdge(0, 0);
+        // when
+        var res = g.getNodesReachableFrom(0);
+        // then
+        Set<Integer> expected = new HashSet<>();
+        expected.add(0);
+        assertEquals(expected, res);
+    }
+
+    @Test
+    void given_directed0to1_when_getNodesReachableFrom0_Return1() {
+        // given
+        DirectedGraph<Integer> g = new HashGraph<Integer>();
+        g.addDirectedEdge(0, 1);
+        // when
+        var res = g.getNodesReachableFrom(0);
+        // then
+        Set<Integer> expected = new HashSet<>();
+        expected.add(1);
+        assertEquals(expected, res);
+    }
+
+    @Test
+    void given_directed0to1_when_getNodesReachableFrom1_ReturnEmpty() {
+        // given
+        DirectedGraph<Integer> g = new HashGraph<Integer>();
+        g.addDirectedEdge(0, 1);
+        // when
+        var res = g.getNodesReachableFrom(1);
+        // then
+        Set<Integer> expected = new HashSet<>();
+        assertEquals(expected, res);
+    }
+
+    @Test
+    void given_udirectedEmptyGraph_when_getNodesReachableFrom0_ReturnEmpty() {
+        // given
+        UndirectedGraph<Integer> g = new HashGraph<Integer>();
+        // when
+        var res = g.getNodesReachableFrom(0);
+        // then
+        Set<Integer> expected = new HashSet<>();
+        assertEquals(expected, res);
+    }
+
+    @Test
+    void given_undirected0to0_when_getNodesReachableFrom0_Return0() {
+        // given
+        UndirectedGraph<Integer> g = new HashGraph<Integer>();
+        g.addUndirectedEdge(0, 0);
+        // when
+        var res = g.getNodesReachableFrom(0);
+        // then
+        Set<Integer> expected = new HashSet<>();
+        expected.add(0);
+        assertEquals(expected, res);
+    }
+
+    @Test
+    void given_undirected0to1_when_getNodesReachableFrom0_Return1() {
+        // given
+        UndirectedGraph<Integer> g = new HashGraph<Integer>();
+        g.addUndirectedEdge(0, 1);
+        // when
+        var res = g.getNodesReachableFrom(0);
+        // then
+        Set<Integer> expected = new HashSet<>();
+        expected.add(1);
+        assertEquals(expected, res);
+    }
+
+    @Test
+    void given_undirected0to1_when_getNodesReachableFrom1_Return0() {
+        // given
+        UndirectedGraph<Integer> g = new HashGraph<Integer>();
+        g.addUndirectedEdge(0, 1);
+        // when
+        var res = g.getNodesReachableFrom(1);
+        // then
+        Set<Integer> expected = new HashSet<>();
+        expected.add(0);
+        assertEquals(expected, res);
+    }
+}


### PR DESCRIPTION
## Overview:

This branch is about graph representation.

- **Graph interface** is the contract for graphs in general.
- **UndirectedGraph** extends **Graph** by undirected edge specific methods.
- **DirectedGraph** extends **Graph** by undirected edge specific methods.
- **HashGraph** is a naive implementation which supports both **UndirectedGraph** and **DirectedGraph**.
- **HashGraphTest** contains tests for **HashGraph** both as an **UndirectedGraph** and as a **DirectedGraph**.

## Compatibility

This branch has only additions.
No changes, no deletions.

This branch creates a new package called **hu/unideb/inf/utils**, because these classes/interfaces are more general,
so I figured it wouldn't make much sense shoving them into the **hu/unideb/inf/model** package.

Please feel free to critique or suggest changes.