### PR TITLE
Inversion of Control

### DIFF
--- a/src/main/java/hu/unideb/inf/ioc/cache/Cache.java
+++ b/src/main/java/hu/unideb/inf/ioc/cache/Cache.java
@@ -1,0 +1,27 @@
+package hu.unideb.inf.ioc.cache;
+
+/**
+ * A cache is responsible for storing an instance
+ * of the parametrized type.
+ * @param <T> type of cached instance
+ */
+public interface Cache<T> {
+
+    /**
+     * Check whether the cache contains an instance
+     * @return true if cache has non null value
+     */
+    boolean hasCached();
+
+    /**
+     * Gets the cached reference which can be null
+     * @return the currently cached reference
+     */
+    T getCached();
+
+    /**
+     * Sets the currently cached reference to a new instance
+     * @param value new instance to be cached
+     */
+    void cache(T value);
+}

--- a/src/main/java/hu/unideb/inf/ioc/cache/CacheFactory.java
+++ b/src/main/java/hu/unideb/inf/ioc/cache/CacheFactory.java
@@ -1,0 +1,22 @@
+package hu.unideb.inf.ioc.cache;
+
+public class CacheFactory {
+
+    /**
+     * Creates a cache based on the provided parameters
+     * and returns it to the caller.
+     * @param cacheStrategy enum deciding which cache to use
+     * @param <T> type parameter of generic type cache
+     * @return cache of type T
+     */
+    public <T> Cache<T> create(CacheStrategy cacheStrategy) {
+        // IDE will cry about replacing switch,
+        // but maybe in the future this will be expanded
+        switch (cacheStrategy) {
+            case SINGLETON:
+                return new SingletonCache<>();
+            default:
+                return new NoCache<>();
+        }
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/cache/CacheStrategy.java
+++ b/src/main/java/hu/unideb/inf/ioc/cache/CacheStrategy.java
@@ -1,0 +1,6 @@
+package hu.unideb.inf.ioc.cache;
+
+public enum CacheStrategy {
+    SINGLETON,
+    NO_CACHE
+}

--- a/src/main/java/hu/unideb/inf/ioc/cache/NoCache.java
+++ b/src/main/java/hu/unideb/inf/ioc/cache/NoCache.java
@@ -1,0 +1,22 @@
+package hu.unideb.inf.ioc.cache;
+
+/**
+ * This implementation never caches
+ * @param <T> type of cached instance
+ */
+public class NoCache<T> implements Cache<T> {
+
+    @Override
+    public boolean hasCached() {
+        return false;
+    }
+
+    @Override
+    public T getCached() {
+        return null;
+    }
+
+    @Override
+    public void cache(T value) {
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/cache/SingletonCache.java
+++ b/src/main/java/hu/unideb/inf/ioc/cache/SingletonCache.java
@@ -1,0 +1,27 @@
+package hu.unideb.inf.ioc.cache;
+
+/**
+ * This implementation can be set only the first time
+ * @param <T>
+ */
+public class SingletonCache<T> implements Cache<T> {
+
+    private T instance;
+
+    @Override
+    public boolean hasCached() {
+        return instance != null;
+    }
+
+    @Override
+    public T getCached() {
+        return instance;
+    }
+
+    @Override
+    public void cache(T value) {
+        if (this.instance == null) {
+            this.instance = value;
+        }
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/container/BaseContainer.java
+++ b/src/main/java/hu/unideb/inf/ioc/container/BaseContainer.java
@@ -1,0 +1,44 @@
+package hu.unideb.inf.ioc.container;
+
+import hu.unideb.inf.ioc.provider.Provider;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+public class BaseContainer implements Container, ConfigurableContainer {
+
+    private final Map<Class<?>, Provider<?>> providers = new ConcurrentHashMap<>();
+
+    @Override
+    public <T> void configureProvider(Class<T> typeToProvide, Provider<T> provider) {
+        if (hasProvider(typeToProvide)) {
+            throw new ProviderAlreadyConfiguredException("Provider for type " + typeToProvide + " was already registered");
+        }
+        Objects.requireNonNull(provider);
+        providers.put(typeToProvide, provider);
+    }
+
+    @Override
+    public <T> boolean hasProvider(Class<T> requiredProvidedType) {
+        Objects.requireNonNull(requiredProvidedType);
+        return providers.containsKey(requiredProvidedType);
+    }
+
+    @Override
+    public <T> Provider<T> getProvider(Class<T> requiredProvidedType) {
+        Objects.requireNonNull(requiredProvidedType);
+        Provider<?> provider = providers.get(requiredProvidedType);
+        return (Provider<T>) provider;
+    }
+
+    @Override
+    public <T> T getProvided(Class<T> requiredProvidedType) {
+        Provider<T> provider = getProvider(requiredProvidedType);
+        if (provider == null) {
+            throw new ProviderNotFoundException("No provider was configured for type " + requiredProvidedType);
+        }
+        return provider.provide();
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/container/ConfigurableContainer.java
+++ b/src/main/java/hu/unideb/inf/ioc/container/ConfigurableContainer.java
@@ -1,0 +1,22 @@
+package hu.unideb.inf.ioc.container;
+
+import hu.unideb.inf.ioc.provider.Provider;
+
+/**
+ * This interface is used for configuring Providers in a Container.
+ */
+public interface ConfigurableContainer extends Container {
+
+    /**
+     * Configures a Provider for a given type.
+     * <p>
+     * Note: Two Providers cannot be mapped to the same class object.
+     * The second call can throw a ProviderAlreadyConfiguredException.
+     * </p>
+     *
+     * @param typeToProvide class object of the type that the Provider provides
+     * @param provider the Provider to be configured
+     * @param <T> type that the Provider provides
+     */
+    <T> void configureProvider(Class<T> typeToProvide, Provider<T> provider);
+}

--- a/src/main/java/hu/unideb/inf/ioc/container/Container.java
+++ b/src/main/java/hu/unideb/inf/ioc/container/Container.java
@@ -1,0 +1,37 @@
+package hu.unideb.inf.ioc.container;
+
+import hu.unideb.inf.ioc.provider.Provider;
+
+/**
+ * A Container is responsible for managing Providers for different Types.
+ * A Container is also used to get instances of Types from Providers.
+ */
+public interface Container {
+
+    /**
+     * Checks whether the Container holds a Provider for a given Type.
+     * @param requiredProvidedType class object of given type
+     * @param <T> type which the provider provides
+     * @return true if Container holds a Provider
+     */
+    <T> boolean hasProvider(Class<T> requiredProvidedType);
+
+    /**
+     * Returns a Provider for a given type or null.
+     * @param requiredProvidedType class object of given type
+     * @param <T> type which the provider provides
+     * @return provider for the given type or null
+     */
+    <T> Provider<T> getProvider(Class<T> requiredProvidedType);
+
+    /**
+     * Returns an instance from a Provider which was mapped to the Type.
+     * <p>
+     * Note: Can throw ProviderNotFoundException
+     * </p>
+     * @param requiredType class object of given type
+     * @param <T> type which the provider provides
+     * @return instance of type T
+     */
+    <T> T getProvided(Class<T> requiredType);
+}

--- a/src/main/java/hu/unideb/inf/ioc/container/ProviderAlreadyConfiguredException.java
+++ b/src/main/java/hu/unideb/inf/ioc/container/ProviderAlreadyConfiguredException.java
@@ -1,0 +1,7 @@
+package hu.unideb.inf.ioc.container;
+
+public class ProviderAlreadyConfiguredException extends RuntimeException {
+    public ProviderAlreadyConfiguredException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/container/ProviderNotFoundException.java
+++ b/src/main/java/hu/unideb/inf/ioc/container/ProviderNotFoundException.java
@@ -1,0 +1,7 @@
+package hu.unideb.inf.ioc.container;
+
+public class ProviderNotFoundException extends RuntimeException {
+    public ProviderNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/factory/BaseFactory.java
+++ b/src/main/java/hu/unideb/inf/ioc/factory/BaseFactory.java
@@ -1,0 +1,15 @@
+package hu.unideb.inf.ioc.factory;
+
+public abstract class BaseFactory<T> implements Factory<T> {
+
+    private final Class<T> productClass;
+
+    protected BaseFactory(Class<T> productClass) {
+        this.productClass = productClass;
+    }
+
+    @Override
+    public Class<T> getReturnType() {
+        return this.productClass;
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/factory/ConstructorFactory.java
+++ b/src/main/java/hu/unideb/inf/ioc/factory/ConstructorFactory.java
@@ -1,0 +1,27 @@
+package hu.unideb.inf.ioc.factory;
+
+import java.lang.reflect.Constructor;
+
+public class ConstructorFactory<T> extends BaseFactory<T> {
+
+    private final Constructor<?> constructor;
+
+    public ConstructorFactory(Class<T> productClass, Constructor<T> constructor) {
+        super(productClass);
+        this.constructor = constructor;
+    }
+
+    @Override
+    public T newInstance(Object... args) {
+        try {
+            return this.getReturnType().cast(constructor.newInstance(args));
+        } catch (Exception e) {
+            throw new FactoryInstanceCreationException(e);
+        }
+    }
+
+    @Override
+    public Class<?>[] getParameterTypes() {
+        return constructor.getParameterTypes();
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/factory/Factory.java
+++ b/src/main/java/hu/unideb/inf/ioc/factory/Factory.java
@@ -1,0 +1,27 @@
+package hu.unideb.inf.ioc.factory;
+
+/**
+ * A Factory is able to create an object of a given type.
+ * @param <T> type of the creatable object
+ */
+public interface Factory<T> {
+
+    /**
+     * Returns the creatable objects type of this Factory.
+     * @return type of the creatable object
+     */
+    Class<T> getReturnType();
+
+    /**
+     * Creates and returns a new instance of the object.
+     * @param args arguments used in the construction or underlying method call
+     * @return new instance of type
+     */
+    T newInstance(Object... args);
+
+    /**
+     * Return the Parameter types used by the newInstance method
+     * @return an array holding the parameter types
+     */
+    Class<?>[] getParameterTypes();
+}

--- a/src/main/java/hu/unideb/inf/ioc/factory/FactoryFactory.java
+++ b/src/main/java/hu/unideb/inf/ioc/factory/FactoryFactory.java
@@ -1,0 +1,10 @@
+package hu.unideb.inf.ioc.factory;
+
+import java.lang.reflect.Constructor;
+
+public class FactoryFactory {
+
+    public <T> Factory<T> create(Class<T> type, Constructor<T> constructor) {
+        return new ConstructorFactory<>(type, constructor);
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/factory/FactoryInstanceCreationException.java
+++ b/src/main/java/hu/unideb/inf/ioc/factory/FactoryInstanceCreationException.java
@@ -1,0 +1,8 @@
+package hu.unideb.inf.ioc.factory;
+
+public class FactoryInstanceCreationException extends RuntimeException {
+
+    public FactoryInstanceCreationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/onthefly/CyclicDependencyException.java
+++ b/src/main/java/hu/unideb/inf/ioc/onthefly/CyclicDependencyException.java
@@ -1,0 +1,7 @@
+package hu.unideb.inf.ioc.onthefly;
+
+public class CyclicDependencyException extends RuntimeException {
+    public CyclicDependencyException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/onthefly/NoPublicCtorFoundException.java
+++ b/src/main/java/hu/unideb/inf/ioc/onthefly/NoPublicCtorFoundException.java
@@ -1,0 +1,7 @@
+package hu.unideb.inf.ioc.onthefly;
+
+public class NoPublicCtorFoundException extends RuntimeException {
+    public NoPublicCtorFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/onthefly/OnTheFlyConfiguredContainer.java
+++ b/src/main/java/hu/unideb/inf/ioc/onthefly/OnTheFlyConfiguredContainer.java
@@ -1,0 +1,81 @@
+package hu.unideb.inf.ioc.onthefly;
+
+import hu.unideb.inf.ioc.cache.Cache;
+import hu.unideb.inf.ioc.cache.CacheFactory;
+import hu.unideb.inf.ioc.cache.CacheStrategy;
+import hu.unideb.inf.ioc.container.ConfigurableContainer;
+import hu.unideb.inf.ioc.container.Container;
+import hu.unideb.inf.ioc.factory.Factory;
+import hu.unideb.inf.ioc.factory.FactoryFactory;
+import hu.unideb.inf.ioc.provider.Provider;
+import hu.unideb.inf.ioc.provider.ProviderFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.lang.reflect.Constructor;
+import java.util.*;
+import java.util.function.Supplier;
+
+@RequiredArgsConstructor
+public class OnTheFlyConfiguredContainer implements Container {
+
+    private final CacheFactory cacheFactory = new CacheFactory();
+
+    private final FactoryFactory factoryFactory = new FactoryFactory();
+
+    private final ProviderFactory providerFactory = new ProviderFactory();
+
+    private final ConfigurableContainer configurableContainer;
+
+    public <T> void configureSupplier(Class<T> providedType, Supplier<T> supplier, CacheStrategy cacheStrategy) {
+        Cache<T> cache = cacheFactory.create(cacheStrategy);
+        var provider = providerFactory.createProvider(providedType, cache,supplier);
+        configurableContainer.configureProvider(providedType, provider);
+    }
+
+    @Override
+    public <T> boolean hasProvider(Class<T> requiredProvidedType) {
+        return configurableContainer.hasProvider(requiredProvidedType);
+    }
+
+    @Override
+    public <T> Provider<T> getProvider(Class<T> requiredProvidedType) {
+        return configurableContainer.getProvider(requiredProvidedType);
+    }
+
+    @Override
+    public <T> T getProvided(Class<T> requiredType) {
+        if (!hasProvider(requiredType)) {
+            autoConfigureProvider(new HashSet<>(), requiredType);
+        }
+        return getProvider(requiredType).provide();
+    }
+
+    private <T> void autoConfigureProvider(Set<Class<?>> typesCurrentlyUnderAutoConfig, Class<T> requiredType) {
+        if (typesCurrentlyUnderAutoConfig.contains(requiredType)) {
+            throw new CyclicDependencyException("Cyclic dependency was found for class " + requiredType);
+        }
+        typesCurrentlyUnderAutoConfig.add(requiredType);
+        Constructor<T> constructor = getCtorWithMaxArgCountOrThrow(requiredType);
+        Factory<T> factory = factoryFactory.create(requiredType, constructor);
+        Cache<T> cache = cacheFactory.create(CacheStrategy.SINGLETON);
+        try {
+            Arrays.stream(factory.getParameterTypes())
+                    .filter(paramType -> !this.hasProvider(paramType))
+                    .forEach(provider -> this.autoConfigureProvider(typesCurrentlyUnderAutoConfig, provider));
+        } catch (Exception e) {
+            throw new OnTheFlyDependencyConfigurationException("Exception for type " + requiredType + " during auto configuration", e);
+        }
+        var provider = providerFactory.createProvider(requiredType, factory, cache, this);
+        configurableContainer.configureProvider(requiredType, provider);
+        typesCurrentlyUnderAutoConfig.remove(requiredType);
+
+    }
+
+    public <T> Constructor<T> getCtorWithMaxArgCountOrThrow(Class<T> type) {
+        Objects.requireNonNull(type);
+        return Arrays.stream(type.getConstructors())
+                .max(Comparator.comparingInt(a -> a.getParameterTypes().length))
+                .map(ctor -> (Constructor<T>) ctor)
+                .orElseThrow(() -> new NoPublicCtorFoundException("No constructor was found for type " + type));
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/onthefly/OnTheFlyDependencyConfigurationException.java
+++ b/src/main/java/hu/unideb/inf/ioc/onthefly/OnTheFlyDependencyConfigurationException.java
@@ -1,0 +1,7 @@
+package hu.unideb.inf.ioc.onthefly;
+
+public class OnTheFlyDependencyConfigurationException extends RuntimeException {
+    public OnTheFlyDependencyConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/provider/BaseProvider.java
+++ b/src/main/java/hu/unideb/inf/ioc/provider/BaseProvider.java
@@ -1,0 +1,11 @@
+package hu.unideb.inf.ioc.provider;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public abstract class BaseProvider<T> implements Provider<T> {
+
+    @Getter
+    private final Class<T> providedClass;
+}

--- a/src/main/java/hu/unideb/inf/ioc/provider/CachedProvider.java
+++ b/src/main/java/hu/unideb/inf/ioc/provider/CachedProvider.java
@@ -1,0 +1,30 @@
+package hu.unideb.inf.ioc.provider;
+
+import hu.unideb.inf.ioc.cache.Cache;
+
+public abstract class CachedProvider<T> extends BaseProvider<T>{
+
+    private final Cache<T> cache;
+
+    public CachedProvider(Class<T> providedClass, Cache<T> cache) {
+        super(providedClass);
+        this.cache=cache;
+    }
+
+    @Override
+    public final T provide() {
+        if (cache.hasCached()) {
+            return cache.getCached();
+        } else {
+            try {
+                var instance = construct();
+                cache.cache(instance);
+                return instance;
+            } catch (Exception e) {
+                throw new ProviderInstanceCreationFailedException("Instantiation failed for type " + getProvidedClass(), e);
+            }
+        }
+    }
+
+    protected abstract T construct();
+}

--- a/src/main/java/hu/unideb/inf/ioc/provider/ContainerAwareProvider.java
+++ b/src/main/java/hu/unideb/inf/ioc/provider/ContainerAwareProvider.java
@@ -1,0 +1,36 @@
+package hu.unideb.inf.ioc.provider;
+
+import hu.unideb.inf.ioc.cache.Cache;
+import hu.unideb.inf.ioc.container.Container;
+import hu.unideb.inf.ioc.factory.Factory;
+
+import java.util.Arrays;
+
+public class ContainerAwareProvider<T> extends CachedProvider<T> {
+
+    private final Factory<T> factory;
+
+    private final Container container;
+
+    public ContainerAwareProvider(Class<T> providedClass, Cache<T> cache, Factory<T> factory, Container container) {
+        super(providedClass, cache);
+        this.factory = factory;
+        this.container = container;
+    }
+
+    private <C> Provider<C> mapTypeToProvider(Class<C> typeToProvide) {
+        var provider = container.getProvider(typeToProvide);
+        if (provider == null) {
+            provider = new NullProvider<>(typeToProvide);
+        }
+        return provider;
+    }
+
+    @Override
+    protected T construct() {
+        var argsStream = Arrays.stream(factory.getParameterTypes())
+                .map(this::mapTypeToProvider)
+                .map(Provider::provide);
+        return factory.newInstance(argsStream.toArray());
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/provider/NullProvider.java
+++ b/src/main/java/hu/unideb/inf/ioc/provider/NullProvider.java
@@ -1,0 +1,13 @@
+package hu.unideb.inf.ioc.provider;
+
+public class NullProvider<T> extends BaseProvider<T> {
+
+    public NullProvider(Class<T> providedClass) {
+        super(providedClass);
+    }
+
+    @Override
+    public T provide() {
+        throw new ProviderDependencyNotConfiguredException("No provider was available for " + getProvidedClass());
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/provider/Provider.java
+++ b/src/main/java/hu/unideb/inf/ioc/provider/Provider.java
@@ -1,0 +1,24 @@
+package hu.unideb.inf.ioc.provider;
+
+/**
+ * A Provider provides instances for the client.
+ * The Provider not necessarily creates new instances:
+ * The Provider depending on the caching strategy can
+ * return cached instances.
+ * @param <T> type of provided instances
+ */
+public interface Provider<T> {
+
+    /**
+     * Returns the provided type.
+     * @return class object of the provided type
+     */
+    Class<T> getProvidedClass();
+
+    /**
+     * Returns an instance which can be either new or cached,
+     * depending on cache strategy.
+     * @return instance
+     */
+    T provide();
+}

--- a/src/main/java/hu/unideb/inf/ioc/provider/ProviderDependencyNotConfiguredException.java
+++ b/src/main/java/hu/unideb/inf/ioc/provider/ProviderDependencyNotConfiguredException.java
@@ -1,0 +1,7 @@
+package hu.unideb.inf.ioc.provider;
+
+public class ProviderDependencyNotConfiguredException extends RuntimeException {
+    public ProviderDependencyNotConfiguredException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/provider/ProviderFactory.java
+++ b/src/main/java/hu/unideb/inf/ioc/provider/ProviderFactory.java
@@ -1,0 +1,23 @@
+package hu.unideb.inf.ioc.provider;
+
+import hu.unideb.inf.ioc.cache.Cache;
+import hu.unideb.inf.ioc.container.Container;
+import hu.unideb.inf.ioc.factory.Factory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.function.Supplier;
+
+@RequiredArgsConstructor
+public class ProviderFactory {
+
+    public <T> Provider<T> createProvider(Class<T> providedClass,
+                                          Factory<T> factory,
+                                          Cache<T> cache,
+                                          Container container) {
+        return new ContainerAwareProvider<>(providedClass, cache, factory, container);
+    }
+
+    public <T> Provider<T> createProvider(Class<T> providedClass, Cache<T> cache, Supplier<T> supplier) {
+        return new SupplierBasedProvider<>(providedClass, cache, supplier);
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/provider/ProviderInstanceCreationFailedException.java
+++ b/src/main/java/hu/unideb/inf/ioc/provider/ProviderInstanceCreationFailedException.java
@@ -1,0 +1,7 @@
+package hu.unideb.inf.ioc.provider;
+
+public class ProviderInstanceCreationFailedException extends RuntimeException {
+    public ProviderInstanceCreationFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/hu/unideb/inf/ioc/provider/SupplierBasedProvider.java
+++ b/src/main/java/hu/unideb/inf/ioc/provider/SupplierBasedProvider.java
@@ -1,0 +1,20 @@
+package hu.unideb.inf.ioc.provider;
+
+import hu.unideb.inf.ioc.cache.Cache;
+
+import java.util.function.Supplier;
+
+public class SupplierBasedProvider<T> extends CachedProvider<T>{
+
+    private final Supplier<T> supplier;
+
+    public SupplierBasedProvider(Class<T> providedClass, Cache<T> cache, Supplier<T> supplier) {
+        super(providedClass, cache);
+        this.supplier = supplier;
+    }
+
+    @Override
+    protected T construct() {
+        return supplier.get();
+    }
+}

--- a/src/test/java/hu/unideb/inf/ioc/cache/NoCacheTest.java
+++ b/src/test/java/hu/unideb/inf/ioc/cache/NoCacheTest.java
@@ -1,0 +1,51 @@
+package hu.unideb.inf.ioc.cache;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class NoCacheTest {
+
+    @Test
+    void hasCached_CacheNotCalledPrior_ReturnsFalse(){
+        // given
+        NoCache<Integer> cache = new NoCache<>();
+        // when
+        var hasCached = cache.hasCached();
+        // then
+        assertFalse(hasCached);
+    }
+
+    @Test
+    void hasCached_CacheWasCalledPrior_ReturnsFalse(){
+        // given
+        NoCache<Integer> cache = new NoCache<>();
+        cache.cache(1);
+        // when
+        var hasCached = cache.hasCached();
+        // then
+        assertFalse(hasCached);
+    }
+
+    @Test
+    void getCached_CacheWasNotCalledPrior_ReturnsNull(){
+        // given
+        NoCache<Integer> cache = new NoCache<>();
+        // when
+        var cached = cache.getCached();
+        // then
+        assertNull(cached);
+    }
+
+    @Test
+    void getCached_CacheWasCalledPrior_ReturnsNull(){
+        // given
+        NoCache<Integer> cache = new NoCache<>();
+        cache.cache(1);
+        // when
+        var cached = cache.getCached();
+        // then
+        assertNull(cached);
+    }
+}

--- a/src/test/java/hu/unideb/inf/ioc/cache/SingletonCacheTest.java
+++ b/src/test/java/hu/unideb/inf/ioc/cache/SingletonCacheTest.java
@@ -1,0 +1,54 @@
+package hu.unideb.inf.ioc.cache;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SingletonCacheTest {
+
+    public static class A{}
+
+    @Test
+    void hasCached_CacheNotCalledPrior_ReturnsFalse(){
+        // given
+        SingletonCache<A> cache = new SingletonCache<>();
+        // when
+        var hasCached = cache.hasCached();
+        // then
+        assertFalse(hasCached);
+    }
+
+    @Test
+    void hasCached_CacheWasCalledPrior_ReturnsTrue(){
+        // given
+        SingletonCache<A> cache = new SingletonCache<>();
+        cache.cache(new A());
+        // when
+        var hasCached = cache.hasCached();
+        // then
+        assertTrue(hasCached);
+    }
+
+    @Test
+    void getCached_CacheWasNotCalledPrior_ReturnsNull(){
+        // given
+        SingletonCache<A> cache = new SingletonCache<>();
+        // when
+        var cached = cache.getCached();
+        // then
+        assertNull(cached);
+    }
+
+    @Test
+    void getCached_CacheWasCalledPriorWithObject_ReturnsTheCachedInstance(){
+        // given
+        A expected = new A();
+        SingletonCache<A> cache = new SingletonCache<>();
+        cache.cache(expected);
+        // when
+        var cached = cache.getCached();
+        // then
+        assertSame(expected,cached);
+        assertEquals(expected,cached);
+    }
+}

--- a/src/test/java/hu/unideb/inf/ioc/container/BaseContainerTest.java
+++ b/src/test/java/hu/unideb/inf/ioc/container/BaseContainerTest.java
@@ -1,0 +1,132 @@
+package hu.unideb.inf.ioc.container;
+
+import hu.unideb.inf.ioc.cache.CacheFactory;
+import hu.unideb.inf.ioc.cache.CacheStrategy;
+import hu.unideb.inf.ioc.factory.FactoryFactory;
+import hu.unideb.inf.ioc.provider.Provider;
+import hu.unideb.inf.ioc.provider.ProviderFactory;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BaseContainerTest {
+
+    private final CacheFactory cacheFactory = new CacheFactory();
+
+    private final FactoryFactory factoryFactory = new FactoryFactory();
+
+    private final ProviderFactory providerFactory = new ProviderFactory();
+
+    @Data
+    public static class A{
+
+    }
+
+    private Provider<A> getProviderA(Container container, CacheStrategy cacheStrategy) throws NoSuchMethodException {
+        return providerFactory.createProvider(
+                A.class,
+                factoryFactory.create(
+                        A.class,
+                        A.class.getConstructor()),
+                cacheFactory.create(cacheStrategy),
+                container);
+    }
+
+    @Test
+    void hasProvider_ProviderNotConfiguredPrior_ReturnFalse(){
+        // given
+        BaseContainer baseContainer = new BaseContainer();
+        // when, then
+        assertFalse(baseContainer.hasProvider(A.class));
+    }
+
+    @Test
+    void hasProvider_ProviderConfiguredPrior_ReturnTrue() throws NoSuchMethodException {
+        // given
+        BaseContainer baseContainer = new BaseContainer();
+        baseContainer.configureProvider(A.class,getProviderA(baseContainer, CacheStrategy.SINGLETON));
+        // when, then
+        assertTrue(baseContainer.hasProvider(A.class));
+    }
+
+    @Test
+    void getProvider_ProviderNotConfiguredPrior_ReturnNull(){
+        // given
+        BaseContainer baseContainer = new BaseContainer();
+        // when, then
+        assertNull(baseContainer.getProvider(A.class));
+    }
+
+    @Test
+    void getProvider_ProviderConfiguredPrior_ReturnNonNullProvider() throws NoSuchMethodException {
+        // given
+        BaseContainer baseContainer = new BaseContainer();
+        baseContainer.configureProvider(A.class,getProviderA(baseContainer, CacheStrategy.SINGLETON));
+        // when, then
+        assertNotNull(baseContainer.getProvider(A.class));
+    }
+
+    @Test
+    void getProvider_ProviderConfiguredPrior_ReturnSameInstance() throws NoSuchMethodException {
+        // given
+        BaseContainer baseContainer = new BaseContainer();
+        baseContainer.configureProvider(A.class,getProviderA(baseContainer, CacheStrategy.SINGLETON));
+        // when, then
+        var firstResult = baseContainer.getProvider(A.class);
+        var secondResult = baseContainer.getProvider(A.class);
+        // then
+        assertSame(firstResult, secondResult);
+    }
+
+    @Test
+    void getProvided_ProviderNotConfiguredPrior_ThrowProviderNotFoundException() {
+        // given
+        BaseContainer baseContainer = new BaseContainer();
+        // when, then
+        assertThrows(ProviderNotFoundException.class, ()-> baseContainer.getProvided(A.class));
+    }
+
+    @Test
+    void getProvided_ProviderConfiguredWithSingletonCachePrior_ReturnNonNullInstance() throws NoSuchMethodException {
+        // given
+        BaseContainer baseContainer = new BaseContainer();
+        baseContainer.configureProvider(A.class,getProviderA(baseContainer,CacheStrategy.SINGLETON));
+        // when, then
+        assertNotNull(baseContainer.getProvided(A.class));
+    }
+
+    @Test
+    void getProvided_ProviderConfiguredWithNoCachePrior_ReturnNonNullInstance() throws NoSuchMethodException {
+        // given
+        BaseContainer baseContainer = new BaseContainer();
+        baseContainer.configureProvider(A.class,getProviderA(baseContainer,CacheStrategy.NO_CACHE));
+        // when, then
+        assertNotNull(baseContainer.getProvided(A.class));
+    }
+
+    @Test
+    void getProvided_ProviderConfiguredWithSingletonPrior_ReturnInstancesTheSameButEquals() throws NoSuchMethodException {
+        // given
+        BaseContainer baseContainer = new BaseContainer();
+        baseContainer.configureProvider(A.class,getProviderA(baseContainer,CacheStrategy.SINGLETON));
+        // when, then
+        var firstResult = baseContainer.getProvided(A.class);
+        var secondResult = baseContainer.getProvided(A.class);
+        // then
+        assertSame(firstResult, secondResult);
+    }
+
+    @Test
+    void getProvided_ProviderConfiguredWithNoCachePrior_ReturnInstancesNotTheSameButEquals() throws NoSuchMethodException {
+        // given
+        BaseContainer baseContainer = new BaseContainer();
+        baseContainer.configureProvider(A.class,getProviderA(baseContainer,CacheStrategy.NO_CACHE));
+        // when, then
+        var firstResult = baseContainer.getProvided(A.class);
+        var secondResult = baseContainer.getProvided(A.class);
+        // then
+        assertNotSame(firstResult , secondResult);
+        assertEquals(firstResult, secondResult);
+    }
+}

--- a/src/test/java/hu/unideb/inf/ioc/factory/ConstructorFactoryTest.java
+++ b/src/test/java/hu/unideb/inf/ioc/factory/ConstructorFactoryTest.java
@@ -1,0 +1,61 @@
+package hu.unideb.inf.ioc.factory;
+
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConstructorFactoryTest {
+
+    @Data
+    static class A{
+
+    }
+
+    @Test
+    public void getReturnType_InstantiatedWithTypeA_ReturnsTypeA() throws NoSuchMethodException {
+        // given
+        Class<A> expectedType = A.class;
+        Constructor<A> ctor = expectedType.getConstructor();
+        var constructorFactory = new ConstructorFactory<>(expectedType,ctor);
+        // when
+        var productClass = constructorFactory.getReturnType();
+        // then
+        assertEquals(expectedType,productClass);
+    }
+
+    @Test
+    public void newInstance_UsingTypeA_ReturnsInstanceOfTypeA() throws NoSuchMethodException {
+        // given
+        Class<A> expectedType = A.class;
+        var constructorFactory = new ConstructorFactory<>(expectedType,expectedType.getConstructor());
+        // when
+        var result = constructorFactory.newInstance();
+        // then
+        assertEquals(expectedType,result.getClass());
+    }
+
+    @Test
+    public void newInstance_UsingTypeA_ReturnedInstancesAreNotTheSameButEqual() throws NoSuchMethodException {
+        // given
+        Class<A> expectedProductClass = A.class;
+        var constructorFactory = new ConstructorFactory<>(expectedProductClass,expectedProductClass.getConstructor());
+        // when
+        var firstResult = constructorFactory.newInstance();
+        var secondResult = constructorFactory.newInstance();
+        // then
+        assertNotSame(firstResult , secondResult);
+        assertEquals(firstResult , secondResult);
+    }
+
+    @Test
+    public void newInstance_UsingTypeAParamsInvalidForCtor_ThrowsFactoryInstanceCreationException() throws NoSuchMethodException {
+        // given
+        Class<A> expectedProductClass = A.class;
+        var constructorFactory = new ConstructorFactory<>(expectedProductClass,expectedProductClass.getConstructor());
+        // when, then
+        assertThrows(FactoryInstanceCreationException.class,()->constructorFactory.newInstance(1));
+    }
+}

--- a/src/test/java/hu/unideb/inf/ioc/onthefly/OnTheFlyConfiguredContainerTest.java
+++ b/src/test/java/hu/unideb/inf/ioc/onthefly/OnTheFlyConfiguredContainerTest.java
@@ -1,0 +1,264 @@
+package hu.unideb.inf.ioc.onthefly;
+
+import hu.unideb.inf.ioc.cache.CacheStrategy;
+import hu.unideb.inf.ioc.container.BaseContainer;
+import lombok.Data;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class OnTheFlyConfiguredContainerTest {
+
+    OnTheFlyConfiguredContainer onTheFlyConfiguredContainer;
+
+    @BeforeEach
+    void init() {
+        onTheFlyConfiguredContainer = new OnTheFlyConfiguredContainer(new BaseContainer());
+    }
+
+    @Data
+    public static class TypeWithNoPublicConstructor {
+
+        private TypeWithNoPublicConstructor() {
+        }
+    }
+
+    @Test
+    void getCtorWithMaxArgCountOrThrow_ParamNull_ThrowNullPointerException() {
+        assertThrows(NullPointerException.class, () -> onTheFlyConfiguredContainer.getCtorWithMaxArgCountOrThrow(null));
+    }
+
+    @Test
+    void getCtorWithMaxArgCountOrThrow_ParamTypeHasNoPublicCtor_ThrowNoPublicCtorFoundException() {
+        // given, when, then
+        assertThrows(NoPublicCtorFoundException.class, () -> onTheFlyConfiguredContainer.getCtorWithMaxArgCountOrThrow(TypeWithNoPublicConstructor.class));
+    }
+
+    @Data
+    public static class TypeWithTwoConstructors {
+        private Integer a;
+
+        // The IDE will tell you that ctor is never used,
+        // but it is actually necessary for testing our reflection based methods
+        public TypeWithTwoConstructors() {
+        }
+
+        // The IDE will tell you that ctor is never used,
+        // but it is actually necessary for testing our reflection based methods
+        public TypeWithTwoConstructors(Integer a) {
+            this.a = a;
+        }
+    }
+
+    @Test
+    void getCtorWithMaxArgCountOrThrow_ParamTypeHasANumberOfConstructors_ReturnCtorWithMostParameters() throws NoSuchMethodException {
+        // given
+        Class<TypeWithTwoConstructors> expectedType = TypeWithTwoConstructors.class;
+        Constructor<TypeWithTwoConstructors> expected = TypeWithTwoConstructors.class.getConstructor(Integer.class);
+        // when
+        Constructor<TypeWithTwoConstructors> result = onTheFlyConfiguredContainer.getCtorWithMaxArgCountOrThrow(expectedType);
+        // then
+        assertEquals(expected, result);
+    }
+
+    @Data
+    public static class A {
+
+    }
+
+    @Test
+    void getProvided_ParamTypeMaxArgCtorHasNoArgs_ReturnInstanceOfParamType() {
+        // given
+        Class<A> expectedType = A.class;
+        // when, then
+        assertNotNull(onTheFlyConfiguredContainer.getProvided(expectedType));
+    }
+
+    @Test
+    void getProvided_ParamTypeMaxArgCtorHasNoArgs_ReturnSameInstanceAlways() {
+        // given
+        Class<A> expectedType = A.class;
+        // when
+        var firstResult = onTheFlyConfiguredContainer.getProvided(expectedType);
+        var secondResult = onTheFlyConfiguredContainer.getProvided(expectedType);
+        // then
+        assertSame(firstResult, secondResult);
+    }
+
+    @Data
+    public static class B {
+
+        private final A a;
+    }
+
+    @Test
+    void getProvided_ParamTypeHasDependencyOnDefaultConstructable_ReturnSameInstanceAlways() {
+        // given
+        Class<B> expectedType = B.class;
+        // when
+        var firstResult = onTheFlyConfiguredContainer.getProvided(expectedType);
+        var secondResult = onTheFlyConfiguredContainer.getProvided(expectedType);
+        // then
+        assertSame(firstResult, secondResult);
+    }
+
+    @Data
+    public static class C {
+
+        private final B b;
+    }
+
+    @Test
+    void getProvided_ParamTypeDependencyTreeAllNodesAreConstructable_ReturnSameInstanceAlways() {
+        // given
+        Class<C> expectedType = C.class;
+        // when
+        var firstResult = onTheFlyConfiguredContainer.getProvided(expectedType);
+        var secondResult = onTheFlyConfiguredContainer.getProvided(expectedType);
+        // then
+        assertSame(firstResult, secondResult);
+    }
+
+    @Data
+    public static class TypeHasNonConstructableDependency {
+
+        private final C c;
+
+        private final TypeWithNoPublicConstructor nonConstructable;
+    }
+
+    @Test
+    void getProvided_DependencyTreeAnyNodeIsNotConstructable_ThrowsOnTheFlyDependencyConfigurationWithCauseNoPublicCtorFound() {
+        // given
+        Class<TypeHasNonConstructableDependency> expectedType = TypeHasNonConstructableDependency.class;
+        // when, then
+        OnTheFlyDependencyConfigurationException exception = assertThrows(OnTheFlyDependencyConfigurationException.class, () -> onTheFlyConfiguredContainer.getProvided(expectedType));
+        assertEquals(NoPublicCtorFoundException.class, exception.getCause().getClass());
+    }
+
+    @Data
+    public static class TypeHasCyclicDependency {
+
+        private final TypeHasCyclicDependencyOther a;
+    }
+
+    @Data
+    public static class TypeHasCyclicDependencyOther {
+
+        private final TypeHasCyclicDependency a;
+    }
+
+    @Test
+    void getProvided_CyclicDependency_ThrowsOnTheFlyDependencyConfigurationWithCauseCyclicDependency() {
+        // given
+        Class<TypeHasCyclicDependency> expectedType = TypeHasCyclicDependency.class;
+        // when, then
+        OnTheFlyDependencyConfigurationException exception = assertThrows(OnTheFlyDependencyConfigurationException.class, () -> onTheFlyConfiguredContainer.getProvided(expectedType));
+        var exceptionCause = exception.getCause();
+        assertEquals(OnTheFlyDependencyConfigurationException.class, exceptionCause.getClass());
+        var exceptionRootCause = exceptionCause.getCause();
+        assertEquals(CyclicDependencyException.class, exceptionRootCause.getClass());
+        assertNull(exceptionRootCause.getCause());
+    }
+
+    @Data
+    public static class TypeHasDependencyOnSuppliedType {
+
+        private final Integer a;
+    }
+
+    @Test
+    void getProvided_TypeIsSupplierBasedNoCache_ReturnNotTheSameInstanceButEqual() {
+        // given
+        onTheFlyConfiguredContainer.configureSupplier(TypeHasDependencyOnSuppliedType.class, () -> new TypeHasDependencyOnSuppliedType(1), CacheStrategy.NO_CACHE);
+        // when
+        var firstResult = onTheFlyConfiguredContainer.getProvided(TypeHasDependencyOnSuppliedType.class);
+        var secondResult = onTheFlyConfiguredContainer.getProvided(TypeHasDependencyOnSuppliedType.class);
+        // then
+        assertNotSame(firstResult, secondResult);
+        assertEquals(firstResult, secondResult);
+    }
+
+    @Test
+    void getProvided_TypeIsSupplierBasedNoCache_ReturnTheSameInstance() {
+        // given
+        onTheFlyConfiguredContainer.configureSupplier(TypeHasDependencyOnSuppliedType.class, () -> new TypeHasDependencyOnSuppliedType(1), CacheStrategy.SINGLETON);
+        // when
+        var firstResult = onTheFlyConfiguredContainer.getProvided(TypeHasDependencyOnSuppliedType.class);
+        var secondResult = onTheFlyConfiguredContainer.getProvided(TypeHasDependencyOnSuppliedType.class);
+        // then
+        assertSame(firstResult, secondResult);
+    }
+
+    public interface InterfaceA {
+
+    }
+
+    @Data
+    public static class ImplementationA implements InterfaceA {
+
+        private final Integer value;
+    }
+
+    @Test
+    void getProvided_TypeIsInterfaceAndSupplierBasedNoCache_ReturnNotTheSameInstanceButEqual() {
+        // given
+        onTheFlyConfiguredContainer.configureSupplier(InterfaceA.class, () -> new ImplementationA(1), CacheStrategy.NO_CACHE);
+        // when
+        var firstResult = onTheFlyConfiguredContainer.getProvided(InterfaceA.class);
+        var secondResult = onTheFlyConfiguredContainer.getProvided(InterfaceA.class);
+        // then
+        assertNotSame(firstResult, secondResult);
+        assertEquals(firstResult, secondResult);
+    }
+
+    @Test
+    void getProvided_TypeIsInterfaceAndSupplierBasedNoCache_ReturnTheSameInstance() {
+        // given
+        onTheFlyConfiguredContainer.configureSupplier(InterfaceA.class, () -> new ImplementationA(1), CacheStrategy.SINGLETON);
+        // when
+        var firstResult = onTheFlyConfiguredContainer.getProvided(InterfaceA.class);
+        var secondResult = onTheFlyConfiguredContainer.getProvided(InterfaceA.class);
+        // then
+        assertSame(firstResult, secondResult);
+    }
+
+    @Data
+    public static class DependentOnInterfaceA {
+
+        private final InterfaceA interfaceA;
+    }
+
+    @Data
+    public static class DependentOnInterfaceAOther {
+
+        private final InterfaceA interfaceA;
+    }
+
+    @Test
+    void getProvided_DependencyNotCached_AlwaysReturnNewInstancesOfDependency() {
+        // given
+        onTheFlyConfiguredContainer.configureSupplier(InterfaceA.class, () -> new ImplementationA(1), CacheStrategy.NO_CACHE);
+        // when
+        var firstResult = onTheFlyConfiguredContainer.getProvided(DependentOnInterfaceA.class);
+        var secondResult = onTheFlyConfiguredContainer.getProvided(DependentOnInterfaceAOther.class);
+        // then
+        assertNotSame(firstResult.interfaceA, secondResult.interfaceA);
+        assertEquals(firstResult.interfaceA, secondResult.interfaceA);
+    }
+
+    @Test
+    void getProvided_DependencySingletonCached_AlwaysReturnSameInstancesOfDependency() {
+        // given
+        onTheFlyConfiguredContainer.configureSupplier(InterfaceA.class, () -> new ImplementationA(1), CacheStrategy.SINGLETON);
+        // when
+        var firstResult = onTheFlyConfiguredContainer.getProvided(DependentOnInterfaceA.class);
+        var secondResult = onTheFlyConfiguredContainer.getProvided(DependentOnInterfaceAOther.class);
+        // then
+        assertSame(firstResult.interfaceA, secondResult.interfaceA);
+        assertEquals(firstResult.interfaceA, secondResult.interfaceA);
+    }
+}

--- a/src/test/java/hu/unideb/inf/ioc/onthefly/OnTheFlyConfiguredContainerUseCaseTest.java
+++ b/src/test/java/hu/unideb/inf/ioc/onthefly/OnTheFlyConfiguredContainerUseCaseTest.java
@@ -1,0 +1,93 @@
+package hu.unideb.inf.ioc.onthefly;
+
+import hu.unideb.inf.ioc.cache.CacheStrategy;
+import hu.unideb.inf.ioc.container.BaseContainer;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * These test are examples on how in out case the ioc could work.
+ * The main point being the non-intrusiveness.
+ * Aka you don't have to annotate the classes or modify them,
+ * so you can hook them up without changing them.
+ */
+public class OnTheFlyConfiguredContainerUseCaseTest {
+
+    public interface TestIOService{
+
+        String getName();
+    }
+
+    public static class TestIOServiceImpl0 implements TestIOService{
+
+        @Override
+        public String getName(){
+            // just for demonstration purposes
+            // you can do here calls to System.in or
+            // any other calls
+            return "a";
+        }
+    }
+
+    public static class TestIOServiceImpl1 implements TestIOService{
+
+        @Override
+        public String getName(){
+            // just for demonstration purposes
+            // you can do here calls to System.in or
+            // any other calls
+            return "b";
+        }
+    }
+
+    @Data
+    @SuperBuilder
+    public static class TestEntity{
+
+        private Integer hp;
+    }
+
+    @Data
+    @SuperBuilder
+    public static class TestPlayer extends TestEntity{
+
+        private String name;
+    }
+
+
+    @RequiredArgsConstructor
+    public static class TestPlayerService {
+
+        private final TestIOService testIOService;
+
+        public TestPlayer getTestPlayer(){
+            return TestPlayer
+                    .builder()
+                    .hp(100)
+                    .name(testIOService.getName())
+                    .build();
+        }
+    }
+
+    @Test
+    void useCaseExample0(){
+        OnTheFlyConfiguredContainer container = new OnTheFlyConfiguredContainer(new BaseContainer());
+        container.configureSupplier(TestIOService.class,()->new TestIOServiceImpl0(), CacheStrategy.SINGLETON);
+        TestPlayerService testPlayerService = container.getProvided(TestPlayerService.class);
+        var testPlayer = testPlayerService.getTestPlayer();
+        assertEquals("a",testPlayer.getName());
+    }
+
+    @Test
+    void useCaseExample1(){
+        OnTheFlyConfiguredContainer container = new OnTheFlyConfiguredContainer(new BaseContainer());
+        container.configureSupplier(TestIOService.class,()->new TestIOServiceImpl1(), CacheStrategy.SINGLETON);
+        TestPlayerService testPlayerService = container.getProvided(TestPlayerService.class);
+        var testPlayer = testPlayerService.getTestPlayer();
+        assertEquals("b",testPlayer.getName());
+    }
+}

--- a/src/test/java/hu/unideb/inf/ioc/provider/ContainerAwareProviderTest.java
+++ b/src/test/java/hu/unideb/inf/ioc/provider/ContainerAwareProviderTest.java
@@ -1,0 +1,88 @@
+package hu.unideb.inf.ioc.provider;
+
+import hu.unideb.inf.ioc.cache.Cache;
+import hu.unideb.inf.ioc.cache.NoCache;
+import hu.unideb.inf.ioc.cache.SingletonCache;
+import hu.unideb.inf.ioc.container.Container;
+import hu.unideb.inf.ioc.factory.ConstructorFactory;
+import hu.unideb.inf.ioc.factory.Factory;
+import lombok.Data;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ContainerAwareProviderTest {
+
+    public static class MockContainer implements Container {
+
+        @Override
+        public <T> boolean hasProvider(Class<T> requiredProvidedType) {
+            return false;
+        }
+
+        @Override
+        public <T> Provider<T> getProvider(Class<T> requiredProvidedType) {
+            return null;
+        }
+
+        @Override
+        public <T> T getProvided(Class<T> requiredType) {
+            return null;
+        }
+    }
+
+    @Data
+    public static class A{
+
+    }
+
+    Cache<A> aNoCache;
+
+    Cache<A> aSingletonCache;
+
+    Factory<A> aFactory;
+
+    @Data
+    public static class B{
+        private final A a;
+    }
+
+    Cache<B> bNoCache;
+
+    Cache<B> bSingletonCache;
+
+    Factory<B> bFactory;
+
+    @BeforeEach
+    void init() throws NoSuchMethodException {
+        aNoCache = new NoCache<>();
+        aSingletonCache = new SingletonCache<>();
+        aFactory = new ConstructorFactory<>(A.class,A.class.getConstructor());
+        bNoCache = new NoCache<>();
+        bSingletonCache = new SingletonCache<>();
+        bFactory = new ConstructorFactory<>(B.class,B.class.getConstructor(A.class));
+    }
+
+    @Test
+    void provide_NoCache_ReturnsNotTheSameInstanceButEqual(){
+        // given
+        ContainerAwareProvider<A> containerAwareProvider = new ContainerAwareProvider<>(A.class, aNoCache,aFactory,new MockContainer());
+        // when
+        var firstResult = containerAwareProvider.provide();
+        var secondResult = containerAwareProvider.provide();
+        // then
+        assertNotSame(firstResult,secondResult);
+        assertEquals(firstResult,secondResult);
+    }
+
+    @Test
+    void provide_CacheDependenciesMissingFromContainer_ThrowsProviderInstanceCreationFailedWithDependencyNotConfiguredCause(){
+        // given
+        ContainerAwareProvider<B> containerAwareProvider = new ContainerAwareProvider<>(B.class, bSingletonCache,bFactory,new MockContainer());
+        // when, then
+        var exception = assertThrows(ProviderInstanceCreationFailedException.class, containerAwareProvider::provide);
+        // then
+        assertEquals(ProviderDependencyNotConfiguredException.class,exception.getCause().getClass());
+    }
+}

--- a/src/test/java/hu/unideb/inf/ioc/provider/SupplierBasedProviderTest.java
+++ b/src/test/java/hu/unideb/inf/ioc/provider/SupplierBasedProviderTest.java
@@ -1,0 +1,63 @@
+package hu.unideb.inf.ioc.provider;
+
+import hu.unideb.inf.ioc.cache.Cache;
+import hu.unideb.inf.ioc.cache.NoCache;
+import hu.unideb.inf.ioc.cache.SingletonCache;
+import lombok.Data;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SupplierBasedProviderTest {
+
+    @Data
+    public static class A {
+
+        private final Integer a;
+    }
+
+    Cache<A> aNoCache;
+
+    Cache<A> aSingletonCache;
+
+    @BeforeEach
+    void init() {
+        aNoCache = new NoCache<>();
+        aSingletonCache = new SingletonCache<>();
+    }
+
+    @Test
+    void getProvidedClass_InstantiatedForTypeA_ReturnTypeA() {
+        // given
+        Class<A> expectedType = A.class;
+        SupplierBasedProvider<A> supplierBasedProvider = new SupplierBasedProvider<>(expectedType, aNoCache, () -> new A(0));
+        // when, then
+        assertEquals(expectedType, supplierBasedProvider.getProvidedClass());
+    }
+
+    @Test
+    void provide_InstantiatedForTypeAWithNoCache_ReturnNotTheSameInstanceButEqualAlways() {
+        // given
+        Class<A> expectedType = A.class;
+        SupplierBasedProvider<A> supplierBasedProvider = new SupplierBasedProvider<>(expectedType, aNoCache, () -> new A(0));
+        // when
+        var firstResult = supplierBasedProvider.provide();
+        var secondResult = supplierBasedProvider.provide();
+        // then
+        assertNotSame(firstResult, secondResult);
+        assertEquals(firstResult, secondResult);
+    }
+
+    @Test
+    void provide_InstantiatedForTypeAWithSingletonCache_ReturnSameInstanceAlways() {
+        // given
+        Class<A> expectedType = A.class;
+        SupplierBasedProvider<A> supplierBasedProvider = new SupplierBasedProvider<>(expectedType, aSingletonCache, () -> new A(0));
+        // when
+        var firstResult = supplierBasedProvider.provide();
+        var secondResult = supplierBasedProvider.provide();
+        // then
+        assertSame(firstResult, secondResult);
+    }
+}


### PR DESCRIPTION
## Overview

Goal of this branch is to add minimalistic Dependency Injection.
Another requirement is to try doing it in a **non-intrusive** way.
_(so not a lot of work will be required in setting it up, and we could, in the future, drop this ioc easily if someone comes up with a better solution or we start using an actual framework)_

- No annotations, no implementable interfaces , no config files etc.
- Auto configuration for most things
- Support simple use cases, aka **NO** support for prototype beans currently
- Throw exceptions on config errors like cyclic dependency, not resolvable dependencies etc
- Not mess up test names like last time when I started everything with 'given_'

## Usage

Favoring composition over inheritance, so you simply instantiate the container, don't subclass it.
```
OnTheFlyConfiguredContainer container = new OnTheFlyConfiguredContainer(new BaseContainer());
```
Client can add dependency tree _leaves_ with simple suppliers too. 
```
container.configureSupplier(TestIOService.class,()->new TestIOServiceImpl(), CacheStrategy.SINGLETON);
```
Client can simply let the IoC figure out dependencies on the fly, aka recipes are added on the fly implicitly to the container.
```
TestPlayerService testPlayerService = container.getProvided(TestPlayerService.class);
```
In the above case TestPlayerService has a ctor dependency on TestIOService interface.

A full user friendly example was provided in [one of the test classes](https://github.com/rkeeves/prog2-rpg/blob/ioc/src/test/java/hu/unideb/inf/ioc/onthefly/OnTheFlyConfiguredContainerUseCaseTest.java) with interfaces and services locally defined in the test.

## Notes on why I dropped prototypes and args all together

The prototype bean/free variables way was dropped, because the following use case really complicates things, and I don't think we win anything with it.

Consider the following:
- Given prototype bean B which has dependencies String(free variable)
- Given prototype bean A which has dependencies B, String(free variable), String(free variable)

Or in short _(I use ( A x B x C ) to denote a tuple whose elements are from set A, B and C respectively)_:
- (B x String x String)->A
- (String)->B

Let's imagine that a call like this happens:
```
A a = container.get(A.class, "a","b","c");
```
Should this override default auto configuration and return an error because there's no 
(String x String x String)->A 
conversion

Or should we do implicit conversions?
I mean based on the already defined rule:
(String) -> B
we could construct A if we fetch an instance of B during the bean creation like this:
(String x String x String)->(B x String x String)->A

Bye